### PR TITLE
Separate out lines for map function and pass key/values to reduce

### DIFF
--- a/mapreduce/mapper.js
+++ b/mapreduce/mapper.js
@@ -13,7 +13,7 @@ module.exports.mapper = async (event, context, callback) => {
   let mapData = [];
   let emit = emittedData => mapData.push(emittedData);
   eval(data.mapFunction);
-  map(data.data, emit);
+  data.lines.forEach(line => map(line, emit));
 
   let dynamoData = {
     RequestItems: {

--- a/mapreduce/master.js
+++ b/mapreduce/master.js
@@ -10,11 +10,14 @@ const lambda = new AWS.Lambda({
 
 const MAP_CHUNK_SIZE = 300;
 
-async function performReduce(keyValueData, jobId, reduceFunction) {
+async function performReduce(keyValueList, jobId, reduceFunction) {
+  const key = keyValueList.length && keyValueList[0].key;
+  const values = keyValueList.map(pair => pair.value);
   const reducerData = {
-    jobId: jobId,
-    data: keyValueData,
-    reduceFunction: reduceFunction
+    jobId,
+    key,
+    values,
+    reduceFunction
   };
   const params = {
     FunctionName: "back-end-dev-reducer",
@@ -61,7 +64,7 @@ async function performMapReduce(record) {
   for (let i = 0; i < numberOfChunks; i++) {
     const mapperData = {
       jobId: record.dynamodb.NewImage.jobId.S,
-      data: mapData.slice(i * MAP_CHUNK_SIZE, (i + 1) * MAP_CHUNK_SIZE).join(" "),
+      lines: mapData.slice(i * MAP_CHUNK_SIZE, (i + 1) * MAP_CHUNK_SIZE),
       mapFunction: record.dynamodb.NewImage.map.S
     };
     const params = {

--- a/mapreduce/reducer.js
+++ b/mapreduce/reducer.js
@@ -10,7 +10,7 @@ module.exports.reducer = async (event, context, callback) => {
   let reduceData = [];
   let emit = emittedData => reduceData.push(emittedData);
   eval(data.reduceFunction);
-  reduce(data.data, emit);
+  reduce(data.key, data.values, emit);
 
   for (let reduceItem of reduceData) {
     const dynamoData = {


### PR DESCRIPTION
This breaks up the data for the map function so that we call it on lines separately rather than all at once.

It also calls the reducer with a key/values combo rather than just `data`.  This should make it easier for the user to understand the function